### PR TITLE
Increment sequence on every transaction

### DIFF
--- a/state/actions/sendTransaction.ts
+++ b/state/actions/sendTransaction.ts
@@ -24,6 +24,10 @@ export const sendTransaction = async (account: IAccount, txOptions: TransactionO
         Fee,  // TODO auto-fillable
         ...opts
     };
+    const currAcc = state.accounts.find(acc => acc.address === account.address);
+    if (currAcc) {
+        currAcc.sequence = account.sequence + 1;
+    }
     const { logPrefix = '' } = options || {}
     try {
         const signedAccount = derive.familySeed(account.secret);


### PR DESCRIPTION
This PR fixes issue #103 

After every transaction we will increment the account sequence by one