### PR TITLE
Fix problem with accounts

### DIFF
--- a/components/DebugStream.tsx
+++ b/components/DebugStream.tsx
@@ -112,7 +112,7 @@ const DebugStream = () => {
       // Filter out account_info and account_objects requests
       try {
         const parsed = JSON.parse(log.jsonData);
-        if (parsed.id.includes("hooks-builder-req")) {
+        if (parsed?.id?._Request?.includes("hooks-builder-req")) {
           return;
         }
       } catch (err) {

--- a/state/actions/addFaucetAccount.ts
+++ b/state/actions/addFaucetAccount.ts
@@ -59,6 +59,7 @@ export const addFaucetAccount = async (showToast: boolean = false) => {
         sequence: 1,
         hooks: [],
         isLoading: false,
+        version: '2'
       });
     }
   }

--- a/state/actions/deployHook.ts
+++ b/state/actions/deployHook.ts
@@ -151,7 +151,7 @@ export const deleteHook = async (account: IAccount & { name?: string }) => {
       Account: account.address,
       TransactionType: "SetHook",
       Sequence: account.sequence,
-      Fee: "100000",
+      Fee: "1000000",
       Hooks: [
         {
           Hook: {

--- a/state/index.ts
+++ b/state/index.ts
@@ -34,6 +34,7 @@ export interface IAccount {
   sequence: number;
   hooks: string[];
   isLoading: boolean;
+  version?: string;
 }
 
 export interface ILog {
@@ -119,6 +120,8 @@ if (typeof window !== "undefined") {
   if (localStorageAccounts) {
     initialAccounts = JSON.parse(localStorageAccounts);
   }
+  // filter out old accounts (they do not have version property at all)
+  initialAccounts = initialAccounts.filter(acc => acc.version === '2');
 }
 
 // Initialize state


### PR DESCRIPTION
This PR adds `version` property to accounts in localhost. This way we can remove the accounts that were related to hooks network v1 and do the same thing in the future