### PR TITLE
Convert hook params to hex blobs

### DIFF
--- a/state/actions/deployHook.ts
+++ b/state/actions/deployHook.ts
@@ -15,7 +15,7 @@ const hash = async (string: string) => {
   return hashHex;
 }
 
-function toHex(str) {
+function toHex(str: string) {
   var result = '';
   for (var i = 0; i < str.length; i++) {
     result += str.charCodeAt(i).toString(16);


### PR DESCRIPTION
IDE sent the hook parameters as typed in UI, now before sending we're converting them to hex blobs and they should work.