### PR TITLE
Fixes issue #86 again, regressed in #107 for Firefox

### DIFF
--- a/components/LogBox.tsx
+++ b/components/LogBox.tsx
@@ -215,6 +215,7 @@ export const Log: FC<ILog> = ({
         )}
         {expanded && jsonData && <Pre block>{jsonData}</Pre>}
       </LogText>
+      <br />
     </>
   );
 };


### PR DESCRIPTION
This should fix #86 again. Newlines worked for other browsers than Firefox, this seems to be some Firefox specific thing that other users are having problems as well. 