### PR TITLE
take default header names from /api/header-files JSON

### DIFF
--- a/state/actions/fetchFiles.ts
+++ b/state/actions/fetchFiles.ts
@@ -23,7 +23,6 @@ export const fetchFiles = (gistId: string) => {
           return res
         }
         // in case of templates, fetch header file(s) and append to res
-        let resHeaderJson;
         try {
           const resHeader = await fetch(`${process.env.NEXT_PUBLIC_COMPILE_API_BASE_URL}/api/header-files`);
           if (resHeader.ok) {


### PR DESCRIPTION
This is a client-side upgrade for the server-side https://github.com/XRPLF/xrpl-hooks-compiler/pull/17 - not hard-coding expected header names but taking them from the compilation backend.