### PR TITLE
add: nft transaction type + recalculate `start`

### DIFF
--- a/utils/hookOnCalculator.ts
+++ b/utils/hookOnCalculator.ts
@@ -18,13 +18,18 @@ export const tts = {
   ttDEPOSIT_PREAUTH: 19,
   ttTRUST_SET: 20,
   ttACCOUNT_DELETE: 21,
-  ttHOOK_SET: 22
+  ttHOOK_SET: 22,
+  ttNFTOKEN_MINT: 25,
+  ttNFTOKEN_BURN: 26,
+  ttNFTOKEN_CREATE_OFFER: 27,
+  ttNFTOKEN_CANCEL_OFFER: 28,
+  ttNFTOKEN_ACCEPT_OFFER: 29
 };
 
 export type TTS = typeof tts;
 
 const calculateHookOn = (arr: (keyof TTS)[]) => {
-  let start = '0x00000000003ff5bf';
+  let start = '0x000000003e3ff5bf';
   arr.forEach(n => {
     let v = BigInt(start);
     v ^= (BigInt(1) << BigInt(tts[n as keyof TTS]));


### PR DESCRIPTION
The hook on calculator is missing transactions. I have added the transactions and you also need to recalculate the "No Hook" start.

- [x] Add Missing Transaction Type
- [x] Adjust `start` value for no hooks