### PR TITLE
Fix json mode.

### DIFF
--- a/components/Transaction/index.tsx
+++ b/components/Transaction/index.tsx
@@ -3,6 +3,7 @@ import { FC, useCallback, useEffect } from "react";
 import { useSnapshot } from "valtio";
 import state from "../../state";
 import {
+  getTxFields,
   modifyTransaction,
   prepareState,
   prepareTransaction,
@@ -54,9 +55,7 @@ const Transaction: FC<TransactionProps> = ({
       } = state;
 
       const TransactionType = selectedTransaction?.value || null;
-      const Destination =
-        selectedDestAccount?.value ||
-        (txFields && "Destination" in txFields ? null : undefined);
+      const Destination = selectedDestAccount?.value || txFields?.Destination;
       const Account = selectedAccount?.value || null;
 
       return prepareTransaction({
@@ -108,8 +107,9 @@ const Transaction: FC<TransactionProps> = ({
       }
       const options = prepareOptions(st);
 
-      if (options.Destination === null) {
-        throw Error("Destination account cannot be null");
+      const fields = getTxFields(options.TransactionType);
+      if (fields.Destination && !options.Destination) {
+        throw Error("Destination account is required!");
       }
 
       await sendTransaction(account, options, { logPrefix });

--- a/components/Transaction/json.tsx
+++ b/components/Transaction/json.tsx
@@ -66,6 +66,7 @@ export const TxJson: FC<JsonProps> = ({
     showAlert("Confirm", {
       body: "Are you sure to discard these changes?",
       confirmText: "Yes",
+      onCancel: () => {},
       onConfirm: () => setState({ editorValue: value }),
     });
   };

--- a/components/Transaction/json.tsx
+++ b/components/Transaction/json.tsx
@@ -29,10 +29,17 @@ export const TxJson: FC<JsonProps> = ({
   setState,
 }) => {
   const { editorSettings, accounts } = useSnapshot(state);
-  const { editorValue = getJsonString?.(), estimatedFee } = txState;
+  const { editorValue, estimatedFee } = txState;
   const [currTxType, setCurrTxType] = useState<string | undefined>(
     txState.selectedTransaction?.value
   );
+
+  useEffect(() => {
+    setState({
+      editorValue: getJsonString?.(),
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     const parsed = parseJSON(editorValue);

--- a/components/Transaction/ui.tsx
+++ b/components/Transaction/ui.tsx
@@ -38,7 +38,6 @@ export const TxUI: FC<UIProps> = ({
     txFields,
   } = txState;
 
-
   const transactionsOptions = transactionsData.map(tx => ({
     value: tx.TransactionType,
     label: tx.TransactionType,
@@ -115,8 +114,7 @@ export const TxUI: FC<UIProps> = ({
     k => !specialFields.includes(k)
   ) as [keyof TxFields];
 
-  const switchToJson = () =>
-    setState({ editorSavedValue: null, viewType: "json" });
+  const switchToJson = () => setState({ viewType: "json" });
 
   // default tx
   useEffect(() => {

--- a/components/Transaction/ui.tsx
+++ b/components/Transaction/ui.tsx
@@ -7,9 +7,10 @@ import Text from "../Text";
 import {
   SelectOption,
   TransactionState,
-  transactionsData,
+  transactionsOptions,
   TxFields,
   getTxFields,
+  defaultTransactionType,
 } from "../../state/transactions";
 import { useSnapshot } from "valtio";
 import state from "../../state";
@@ -38,11 +39,6 @@ export const TxUI: FC<UIProps> = ({
     txFields,
   } = txState;
 
-  const transactionsOptions = transactionsData.map(tx => ({
-    value: tx.TransactionType,
-    label: tx.TransactionType,
-  }));
-
   const accountOptions: SelectOption[] = accounts.map(acc => ({
     label: acc.name,
     value: acc.address,
@@ -57,7 +53,7 @@ export const TxUI: FC<UIProps> = ({
 
   const [feeLoading, setFeeLoading] = useState(false);
 
-  const resetOptions = useCallback(
+  const resetFields = useCallback(
     (tt: string) => {
       const fields = getTxFields(tt);
 
@@ -107,11 +103,11 @@ export const TxUI: FC<UIProps> = ({
     (tt: SelectOption) => {
       setState({ selectedTransaction: tt });
 
-      const newState = resetOptions(tt.value);
+      const newState = resetFields(tt.value);
 
       handleEstimateFee(newState, true);
     },
-    [handleEstimateFee, resetOptions, setState]
+    [handleEstimateFee, resetFields, setState]
   );
 
   const switchToJson = () => setState({ viewType: "json" });
@@ -120,13 +116,10 @@ export const TxUI: FC<UIProps> = ({
   useEffect(() => {
     if (selectedTransaction?.value) return;
 
-    const defaultOption = transactionsOptions.find(
-      tt => tt.value === "Payment"
-    );
-    if (defaultOption) {
-      handleChangeTxType(defaultOption);
+    if (defaultTransactionType) {
+      handleChangeTxType(defaultTransactionType);
     }
-  }, [handleChangeTxType, selectedTransaction?.value, transactionsOptions]);
+  }, [handleChangeTxType, selectedTransaction?.value]);
 
   const fields = useMemo(
     () => getTxFields(selectedTransaction?.value),

--- a/components/Transaction/ui.tsx
+++ b/components/Transaction/ui.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useEffect, useState } from "react";
+import { FC, useCallback, useEffect, useMemo, useState } from "react";
 import Container from "../Container";
 import Flex from "../Flex";
 import Input from "../Input";
@@ -60,7 +60,13 @@ export const TxUI: FC<UIProps> = ({
   const resetOptions = useCallback(
     (tt: string) => {
       const fields = getTxFields(tt);
-      if (!fields.Destination) setState({ selectedDestAccount: null });
+
+      if (fields.Destination !== undefined) {
+        setState({ selectedDestAccount: null });
+        fields.Destination = "";
+      } else {
+        fields.Destination = undefined;
+      }
       return setState({ txFields: fields });
     },
     [setState]
@@ -108,12 +114,6 @@ export const TxUI: FC<UIProps> = ({
     [handleEstimateFee, resetOptions, setState]
   );
 
-  const specialFields = ["TransactionType", "Account", "Destination"];
-
-  const otherFields = Object.keys(txFields).filter(
-    k => !specialFields.includes(k)
-  ) as [keyof TxFields];
-
   const switchToJson = () => setState({ viewType: "json" });
 
   // default tx
@@ -127,6 +127,20 @@ export const TxUI: FC<UIProps> = ({
       handleChangeTxType(defaultOption);
     }
   }, [handleChangeTxType, selectedTransaction?.value, transactionsOptions]);
+
+  const fields = useMemo(
+    () => getTxFields(selectedTransaction?.value),
+    [selectedTransaction?.value]
+  );
+
+  const specialFields = ["TransactionType", "Account"];
+  if (fields.Destination !== undefined) {
+    specialFields.push("Destination");
+  }
+
+  const otherFields = Object.keys(txFields).filter(
+    k => !specialFields.includes(k)
+  ) as [keyof TxFields];
 
   return (
     <Container
@@ -183,7 +197,7 @@ export const TxUI: FC<UIProps> = ({
             onChange={(acc: any) => handleSetAccount(acc)} // TODO make react-select have correct types for acc
           />
         </Flex>
-        {txFields.Destination !== undefined && (
+        {fields.Destination !== undefined && (
           <Flex
             row
             fluid

--- a/content/transactions.json
+++ b/content/transactions.json
@@ -55,7 +55,8 @@
     "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
     "TransactionType": "EscrowCancel",
     "Owner": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-    "OfferSequence": 7
+    "OfferSequence": 7,
+    "Fee": "10"
   },
   {
     "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
@@ -69,7 +70,8 @@
     "FinishAfter": 533171558,
     "Condition": "A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100",
     "DestinationTag": 23480,
-    "SourceTag": 11747
+    "SourceTag": 11747,
+    "Fee": "10"
   },
   {
     "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
@@ -77,7 +79,8 @@
     "Owner": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
     "OfferSequence": 7,
     "Condition": "A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100",
-    "Fulfillment": "A0028000"
+    "Fulfillment": "A0028000",
+    "Fee": "10"
   },
   {
     "TransactionType": "NFTokenMint",
@@ -118,7 +121,8 @@
       "$type": "xrp"
     },
     "Flags": 1,
-    "Destination": ""
+    "Destination": "",
+    "Fee": "10"
   },
   {
     "TransactionType": "OfferCancel",
@@ -166,7 +170,8 @@
     "PublicKey": "32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A",
     "CancelAfter": 533171558,
     "DestinationTag": 23480,
-    "SourceTag": 11747
+    "SourceTag": 11747,
+    "Fee": "10"
   },
   {
     "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
@@ -176,7 +181,8 @@
       "$value": "200",
       "$type": "xrp"
     },
-    "Expiration": 543171558
+    "Expiration": 543171558,
+    "Fee": "10"
   },
   {
     "Flags": 0,

--- a/content/transactions.json
+++ b/content/transactions.json
@@ -117,7 +117,8 @@
       "$value": "100",
       "$type": "xrp"
     },
-    "Flags": 1
+    "Flags": 1,
+    "Destination": ""
   },
   {
     "TransactionType": "OfferCancel",

--- a/state/transactions.ts
+++ b/state/transactions.ts
@@ -134,7 +134,7 @@ export const prepareTransaction = (data: any) => {
             delete options[field];
         }
     });
-    
+
     return options
 }
 
@@ -196,7 +196,7 @@ export const prepareState = (value: string, transactionType?: string) => {
             tx.selectedDestAccount = null
         }
     }
-    else if (Destination) { 
+    else if (Destination) {
         rest.Destination = Destination
     }
 
@@ -243,3 +243,10 @@ export const getTxFields = (tt?: string) => {
 }
 
 export { transactionsData }
+
+export const transactionsOptions = transactionsData.map(tx => ({
+    value: tx.TransactionType,
+    label: tx.TransactionType,
+}));
+
+export const defaultTransactionType = transactionsOptions.find(tt => tt.value === 'Payment')

--- a/state/transactions.ts
+++ b/state/transactions.ts
@@ -24,7 +24,7 @@ export interface TransactionState {
 
 
 export type TxFields = Omit<
-    typeof transactionsData[0],
+    Partial<typeof transactionsData[0]>,
     "Account" | "Sequence" | "TransactionType"
 >;
 

--- a/state/transactions.ts
+++ b/state/transactions.ts
@@ -18,7 +18,6 @@ export interface TransactionState {
     txIsDisabled: boolean;
     txFields: TxFields;
     viewType: 'json' | 'ui',
-    editorSavedValue: null | string,
     editorValue?: string,
     estimatedFee?: string
 }
@@ -36,15 +35,14 @@ export const defaultTransaction: TransactionState = {
     txIsLoading: false,
     txIsDisabled: false,
     txFields: {},
-    viewType: 'ui',
-    editorSavedValue: null
+    viewType: 'ui'
 };
 
 export const transactionsState = proxy({
     transactions: [
         {
             header: "test1.json",
-            state: defaultTransaction,
+            state: { ...defaultTransaction },
         },
     ],
     activeHeader: "test1.json"
@@ -218,7 +216,6 @@ export const prepareState = (value: string, transactionType?: string) => {
     });
 
     tx.txFields = rest;
-    tx.editorSavedValue = null;
 
     return tx
 }

--- a/state/transactions.ts
+++ b/state/transactions.ts
@@ -90,7 +90,7 @@ export const modifyTransaction = (
     }
 
     Object.keys(partialTx).forEach(k => {
-        // Typescript mess here, but is definetly safe!
+        // Typescript mess here, but is definitely safe!
         const s = tx.state as any;
         const p = partialTx as any; // ? Make copy
         if (!deepEqual(s[k], p[k])) s[k] = p[k];
@@ -130,11 +130,11 @@ export const prepareTransaction = (data: any) => {
         }
 
         // delete unnecessary fields
-        if (options[field] === undefined) {
+        if (!options[field]) {
             delete options[field];
         }
     });
-
+    
     return options
 }
 
@@ -150,7 +150,7 @@ export const prepareState = (value: string, transactionType?: string) => {
 
     const { Account, TransactionType, Destination, ...rest } = options;
     let tx: Partial<TransactionState> = {};
-    const txFields = getTxFields(transactionType)
+    const schema = getTxFields(transactionType)
 
     if (Account) {
         const acc = state.accounts.find(acc => acc.address === Account);
@@ -178,9 +178,8 @@ export const prepareState = (value: string, transactionType?: string) => {
         tx.selectedTransaction = null;
     }
 
-    if (txFields.Destination !== undefined) {
+    if (schema.Destination !== undefined) {
         const dest = state.accounts.find(acc => acc.address === Destination);
-        rest.Destination = null
         if (dest) {
             tx.selectedDestAccount = {
                 label: dest.name,
@@ -197,11 +196,14 @@ export const prepareState = (value: string, transactionType?: string) => {
             tx.selectedDestAccount = null
         }
     }
+    else if (Destination) { 
+        rest.Destination = Destination
+    }
 
     Object.keys(rest).forEach(field => {
         const value = rest[field];
-        const origValue = txFields[field as keyof TxFields]
-        const isXrp = typeof value !== 'object' && origValue && typeof origValue === 'object' && origValue.$type === 'xrp'
+        const schemaVal = schema[field as keyof TxFields]
+        const isXrp = typeof value !== 'object' && schemaVal && typeof schemaVal === 'object' && schemaVal.$type === 'xrp'
         if (isXrp) {
             rest[field] = {
                 $type: "xrp",


### PR DESCRIPTION
Fixes #252 
 - Adds cancel option to discard dialog in json mode.
 - Fixes issue where u could not save json tx in some cases.
 - About `Transaction changes on Save/Submit`. It's just reordering of fields in json mode, helps in comparing values efficiently, therefore keeping for now.
 - Fixes issue where Destination field was removed in some transactions, therefore not possible to add that field in `NFTokenCreateOffer`. Destination is now handled correctly, moreover `NFTokenCreateOffer` now includes `Destination` field as default too.