### PR TITLE
Deploy config default fields from source files.

### DIFF
--- a/components/SetHookDialog.tsx
+++ b/components/SetHookDialog.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { Plus, Trash, X } from "phosphor-react";
-import { Button, Box } from ".";
+import { Button, Box, Text } from ".";
 import { Stack, Flex, Select } from ".";
 import {
   Dialog,
@@ -30,6 +30,7 @@ import {
   transactionOptions,
   SetHookData,
 } from "../utils/setHook";
+import { capitalize } from "../utils/helpers";
 
 export const SetHookDialog: React.FC<{ accountAddress: string }> = React.memo(
   ({ accountAddress }) => {
@@ -250,6 +251,7 @@ export const SetHookDialog: React.FC<{ accountAddress: string }> = React.memo(
                             <Input
                               // important to include key with field's id
                               placeholder="Parameter name"
+                              readOnly={field.$metaData?.required}
                               {...register(
                                 `HookParameters.${index}.HookParameter.HookParameterName`
                               )}
@@ -258,7 +260,8 @@ export const SetHookDialog: React.FC<{ accountAddress: string }> = React.memo(
                               css={{ mx: "$2" }}
                               placeholder="Value (hex-quoted)"
                               {...register(
-                                `HookParameters.${index}.HookParameter.HookParameterValue`
+                                `HookParameters.${index}.HookParameter.HookParameterValue`,
+                                { required: field.$metaData?.required }
                               )}
                             />
                             <Button
@@ -268,8 +271,12 @@ export const SetHookDialog: React.FC<{ accountAddress: string }> = React.memo(
                               <Trash weight="regular" size="16px" />
                             </Button>
                           </Flex>
+                          {errors.HookParameters?.[index]?.HookParameter
+                            ?.HookParameterValue?.type === "required" && (
+                            <Text error>This field is required</Text>
+                          )}
                           <Label css={{ fontSize: "$sm", mt: "$1" }}>
-                            {field.$metaData?.description}
+                            {capitalize(field.$metaData?.description)}
                           </Label>
                         </Flex>
                       </Stack>

--- a/components/SetHookDialog.tsx
+++ b/components/SetHookDialog.tsx
@@ -31,7 +31,6 @@ import {
   SetHookData,
 } from "../utils/setHook";
 
-
 export const SetHookDialog: React.FC<{ accountAddress: string }> = React.memo(
   ({ accountAddress }) => {
     const snap = useSnapshot(state);
@@ -256,6 +255,7 @@ export const SetHookDialog: React.FC<{ accountAddress: string }> = React.memo(
                               )}
                             />
                             <Input
+                              css={{ mx: "$2" }}
                               placeholder="Value (hex-quoted)"
                               {...register(
                                 `HookParameters.${index}.HookParameter.HookParameterValue`

--- a/state/actions/deployHook.tsx
+++ b/state/actions/deployHook.tsx
@@ -3,10 +3,10 @@ import toast from "react-hot-toast";
 
 import state, { IAccount } from "../index";
 import calculateHookOn, { TTS } from "../../utils/hookOnCalculator";
-import { SetHookData } from "../../components/SetHookDialog";
 import { Link } from "../../components";
 import { ref } from "valtio";
 import estimateFee from "../../utils/estimateFee";
+import { SetHookData } from '../../utils/setHook';
 
 export const sha256 = async (string: string) => {
   const utf8 = new TextEncoder().encode(string);

--- a/utils/setHook.ts
+++ b/utils/setHook.ts
@@ -42,6 +42,7 @@ export const getParameters = (content?: string) => {
         },
         $metaData: {
             description: tag.description,
+            required: !tag.optional
         },
     }));
 

--- a/utils/setHook.ts
+++ b/utils/setHook.ts
@@ -1,0 +1,77 @@
+import { getTags } from './comment-parser';
+import { tts, TTS } from './hookOnCalculator';
+
+export const transactionOptions = Object.keys(tts).map(key => ({
+    label: key,
+    value: key as keyof TTS,
+}));
+
+export type SetHookData = {
+    Invoke: {
+        value: keyof TTS;
+        label: string;
+    }[];
+    Fee: string;
+    HookNamespace: string;
+    HookParameters: {
+        HookParameter: {
+            HookParameterName: string;
+            HookParameterValue: string;
+        };
+        $metaData?: any;
+    }[];
+    // HookGrants: {
+    //   HookGrant: {
+    //     Authorize: string;
+    //     HookHash: string;
+    //   };
+    // }[];
+};
+
+
+export const getParameters = (content?: string) => {
+    const fieldTags = ["field", "param", "arg", "argument"];
+    const tags = getTags(content)
+        .filter(tag => fieldTags.includes(tag.tag))
+        .filter(tag => !!tag.name);
+
+    const paramters: SetHookData["HookParameters"] = tags.map(tag => ({
+        HookParameter: {
+            HookParameterName: tag.name,
+            HookParameterValue: tag.default || "",
+        },
+        $metaData: {
+            description: tag.description,
+        },
+    }));
+
+    return paramters;
+};
+
+export const getInvokeOptions = (content?: string) => {
+    const invokeTags = ["invoke", "invoke-on"];
+
+    const options = getTags(content)
+        .filter(tag => invokeTags.includes(tag.tag))
+        .reduce((cumm, curr) => {
+            const combined = curr.type || `${curr.name} ${curr.description}`
+            const opts = combined.split(' ')
+
+            return cumm.concat(opts as any)
+        }, [] as (keyof TTS)[])
+        .filter(opt => Object.keys(tts).includes(opt))
+
+
+    const invokeOptions: SetHookData['Invoke'] = options.map(opt => ({
+        label: opt,
+        value: opt
+    }))
+
+    // default
+    if (!invokeOptions.length) {
+        const payment = transactionOptions.find(tx => tx.value === "ttPAYMENT")
+        if (payment) return [payment]
+    }
+
+    return invokeOptions;
+};


### PR DESCRIPTION
Fixes #146 

Adds support to default pre-filling of the following.
- Parameters:
Tags used: `field`, `param`, `arg`, `argument`
eg:
```js
/**
 * @field [name=value] Some description of the field
 */
```
- Invoke options: 
Tags used: `invoke`, `invoke-on`
eg: 
```js
/**
 * @invoke ttPAYEMENT ttACCOUNT_SET 
*/
```
All invoke options can be on single line or multiple lines in a comment block or even spread over multiple comment blocks just like `@input` and `@field` tags.