### PR TITLE
Fix tx json saving and discarding.

### DIFF
--- a/components/Transaction/index.tsx
+++ b/components/Transaction/index.tsx
@@ -201,6 +201,15 @@ const Transaction: FC<TransactionProps> = ({ header, state: txState, ...props })
     [accounts, prepareOptions, setState, txState]
   )
 
+  const switchToJson = useCallback(() => {
+    const editorValue = getJsonString()
+    setState({ viewType: 'json', editorValue })
+  }, [getJsonString, setState])
+
+  const switchToUI = useCallback(() => {
+    setState({ viewType: 'ui' })
+  }, [setState])
+
   return (
     <Box css={{ position: 'relative', height: 'calc(100% - 28px)' }} {...props}>
       {viewType === 'json' ? (
@@ -213,6 +222,7 @@ const Transaction: FC<TransactionProps> = ({ header, state: txState, ...props })
         />
       ) : (
         <TxUI
+          switchToJson={switchToJson}
           state={txState}
           resetState={resetState}
           setState={setState}
@@ -233,8 +243,8 @@ const Transaction: FC<TransactionProps> = ({ header, state: txState, ...props })
         <Button
           onClick={() => {
             if (viewType === 'ui') {
-              setState({ viewType: 'json' })
-            } else setState({ viewType: 'ui' })
+              switchToJson()
+            } else switchToUI()
           }}
           outline
         >

--- a/components/Transaction/json.tsx
+++ b/components/Transaction/json.tsx
@@ -11,7 +11,7 @@ import Monaco from '../Monaco'
 import type monaco from 'monaco-editor'
 
 interface JsonProps {
-  getJsonString?: (state?: Partial<TransactionState>) => string
+  getJsonString: (state?: Partial<TransactionState>) => string
   header?: string
   setState: (pTx?: Partial<TransactionState> | undefined) => void
   state: TransactionState
@@ -24,13 +24,6 @@ export const TxJson: FC<JsonProps> = ({ getJsonString, state: txState, header, s
   const [currTxType, setCurrTxType] = useState<string | undefined>(
     txState.selectedTransaction?.value
   )
-
-  useEffect(() => {
-    setState({
-      editorValue: getJsonString?.()
-    })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
 
   useEffect(() => {
     const parsed = parseJSON(editorValue)
@@ -48,9 +41,6 @@ export const TxJson: FC<JsonProps> = ({ getJsonString, state: txState, header, s
     const tx = prepareState(value, transactionType)
     if (tx) {
       setState(tx)
-      setState({
-        editorValue: getJsonString?.(tx)
-      })
     }
   }
 
@@ -59,7 +49,7 @@ export const TxJson: FC<JsonProps> = ({ getJsonString, state: txState, header, s
       body: 'Are you sure to discard these changes?',
       confirmText: 'Yes',
       onCancel: () => {},
-      onConfirm: () => setState({ editorValue: getJsonString?.() })
+      onConfirm: () => setState({ editorValue: getJsonString() })
     })
   }
 
@@ -163,7 +153,7 @@ export const TxJson: FC<JsonProps> = ({ getJsonString, state: txState, header, s
     })
   }, [getSchemas, monacoInst])
 
-  const hasUnsaved = useMemo(() => editorValue !== getJsonString?.(), [editorValue, getJsonString])
+  const hasUnsaved = useMemo(() => editorValue !== getJsonString(), [editorValue, getJsonString])
 
   return (
     <Monaco

--- a/components/Transaction/ui.tsx
+++ b/components/Transaction/ui.tsx
@@ -25,9 +25,16 @@ interface UIProps {
   resetState: (tt?: SelectOption) => TransactionState | undefined
   state: TransactionState
   estimateFee?: (...arg: any) => Promise<string | undefined>
+  switchToJson: () => void
 }
 
-export const TxUI: FC<UIProps> = ({ state: txState, setState, resetState, estimateFee }) => {
+export const TxUI: FC<UIProps> = ({
+  state: txState,
+  setState,
+  resetState,
+  estimateFee,
+  switchToJson
+}) => {
   const { accounts } = useSnapshot(state)
   const {
     selectedAccount,
@@ -101,8 +108,6 @@ export const TxUI: FC<UIProps> = ({ state: txState, setState, resetState, estima
     },
     [handleEstimateFee, resetState, setState]
   )
-
-  const switchToJson = () => setState({ viewType: 'json' })
 
   // default tx
   useEffect(() => {

--- a/state/transactions.ts
+++ b/state/transactions.ts
@@ -36,6 +36,7 @@ export interface TransactionState {
   txFields: TxFields
   viewType: 'json' | 'ui'
   editorValue?: string
+  editorIsSaved: boolean
   estimatedFee?: string
 }
 
@@ -53,6 +54,7 @@ export const defaultTransaction: TransactionState = {
   selectedFlags: null,
   hookParameters: {},
   memos: {},
+  editorIsSaved: true,
   txIsLoading: false,
   txIsDisabled: false,
   txFields: {},
@@ -271,6 +273,7 @@ export const prepareState = (value: string, transactionType?: string) => {
   })
 
   tx.txFields = rest
+  tx.editorIsSaved = true;
 
   return tx
 }


### PR DESCRIPTION
- Fixes: "save" button not removing the 'unsaved' message.
- Fixes: Changes getting lost even after clicking "Cancel" on the Discard confirmation Dialog when exiting Json mode from an erroneous state. 